### PR TITLE
DseSession.Cluster should return an IDseCluster when available.

### DIFF
--- a/src/Dse/DseCluster.cs
+++ b/src/Dse/DseCluster.cs
@@ -112,7 +112,7 @@ namespace Dse
         /// </summary>
         public IDseSession Connect()
         {
-            return new DseSession(_coreCluster.Connect(), _config);
+            return new DseSession(_coreCluster.Connect(), this, _config);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace Dse
         /// </summary>
         public IDseSession Connect(string keyspace)
         {
-            return new DseSession(_coreCluster.Connect(keyspace), _config);
+            return new DseSession(_coreCluster.Connect(keyspace), this, _config);
         }
 
         /// <summary>

--- a/src/Dse/DseSession.cs
+++ b/src/Dse/DseSession.cs
@@ -21,6 +21,7 @@ namespace Dse
         private static readonly Logger Logger = new Logger(typeof(IDseSession));
         private readonly ISession _coreSession;
         private readonly DseConfiguration _config;
+        private readonly ICluster _cluster;
 
         public int BinaryProtocolVersion
         {
@@ -29,7 +30,7 @@ namespace Dse
 
         public ICluster Cluster
         {
-            get { return _coreSession.Cluster; }
+            get { return _cluster; }
         }
 
         public bool IsDisposed
@@ -47,7 +48,12 @@ namespace Dse
             get { return _coreSession.UserDefinedTypes; }
         }
 
-        public DseSession(ISession coreSession, DseConfiguration config)
+        internal DseSession(ISession coreSession, DseConfiguration config) : this(coreSession, coreSession.Cluster, config)
+        {
+            
+        }
+
+        public DseSession(ISession coreSession, ICluster cluster, DseConfiguration config)
         {
             if (coreSession == null)
             {
@@ -57,6 +63,8 @@ namespace Dse
             {
                 throw new ArgumentNullException("config");
             }
+
+            _cluster = cluster;
             _coreSession = coreSession;
             _config = config;
         }


### PR DESCRIPTION
We have to access the configuration of an IDseCluster and found that DseSession.Cluster only returned the underlying Cassandra cluster when a DseCluster is perfectly available. I retained the original DseSession constructor since it's used in tests, however I changed its visibility.